### PR TITLE
Refactor to work with different projects.

### DIFF
--- a/.github/workflows/set_terraform_var_names.yml
+++ b/.github/workflows/set_terraform_var_names.yml
@@ -1,0 +1,79 @@
+name: DR2 Set Terraform secret variable names
+on:
+  workflow_call:
+    inputs:
+      project:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+    outputs:
+      account-number:
+        description: 'The name for the account number variable. PROJECT_ENVIRONMENT_ACCOUNT_NUMBER'
+        value: ${{ jobs.setup.outputs.account-number }}
+      management-account:
+        description: 'The name for the management account number variable. PROJECT_MANAGEMENT_ACCOUNT'
+        value: ${{ jobs.setup.outputs.account-number }}
+      email-address:
+        description: 'The email to send cloud custodian notifications to'
+        value: ${{ jobs.setup.outputs.email }}
+      project-upper:
+        description: 'Upper case project name'
+        value: ${{ jobs.setup.outputs.project-upper }}
+      terraform-role:
+        description: 'The name of the terraform role variable PROJECT_ENVIRONMENT_TERRAFORM_ROLE'
+        value: ${{ jobs.setup.outputs.terraform-role }}
+      custodian-role:
+        description: 'The name of the custodian role variable PROJECT_ENVIRONMENT_CUSTODIAN_ROLE'
+        value: ${{ jobs.setup.outputs.custodian-role }}
+      state-bucket:
+        description: 'The name of the state bucket. These are split by environment but its possible to have one state bucket for all environments'
+        value: ${{ jobs.setup.outputs.state-bucket }}
+      dynamo-table:
+        description: 'The name of the dynamo lock table. These are split by environment but its possible to have one lock table for all environments'
+        value: ${{ jobs.setup.outputs.dynamo-table }}
+      slack-webhook:
+        description: 'The slack webhook for this project'
+        value: ${{ jobs.setup.outputs.slack-webhook }}
+      workflow-token:
+        description: 'The workflow token for this project'
+        value: ${{ jobs.setup.outputs.workflow-token }}
+      terraform-external-id:
+        description: 'The external ID to use with the terraform role'
+        value: ${{ jobs.setup.outputs.terraform-external-id }}
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      account-number: ${{ steps.set-variable-names.outputs.account_number }}
+      management-account: ${{ steps.set-variable-names.outputs.management_account }}
+      email: ${{ steps.set-variable-names.outputs.email }}
+      project-upper: ${{ steps.set-variable-names.outputs.project_upper }}
+      terraform-role: ${{ steps.set-variable-names.outputs.terraform_role }}
+      custodian-role: ${{ steps.set-variable-names.outputs.custodian_role }}
+      state-bucket: ${{ steps.set-variable-names.outputs.state_bucket }}
+      dynamo-table: ${{ steps.set-variable-names.outputs.dynamo_table }}
+      slack-webhook: ${{ steps.set-variable-names.outputs.slack_webhook }}
+      workflow-token: ${{ steps.set-variable-names.outputs.workflow_pat }}
+      terraform-external-id: ${{ steps.set-variable-names.outputs.terraform_external_id }}
+    steps:
+      - id: set-variable-names
+        run: |
+          import os
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+              project = "${{ github.event.inputs.project }}".upper()
+              env = "${{ github.event.inputs.environment }}".upper()
+              print(f"project_upper={project}", file=fh)
+              print(f"environment_upper={env}", file=fh)
+              print(f"management_account={project}_MANAGEMENT_ACCOUNT", file=fh)
+              print(f"management_account={project}_EMAIL_ADDRESS", file=fh)
+              print(f"account_number={project}_{env}_ACCOUNT_NUMBER", file=fh)
+              print(f"terraform_role={project}_{env}_TERRAFORM_ROLE", file=fh)
+              print(f"custodian_role={project}_{env}_CUSTODIAN_ROLE", file=fh)
+              print(f"state_bucket={project}_{env}_STATE_BUCKET", file=fh)
+              print(f"dynamo_table={project}_{env}_DYNAMO_TABLE", file=fh)
+              print(f"slack_webhook={project}_SLACK_WEBHOOK", file=fh)
+              print(f"workflow_pat={project}_WORKFLOW_PAT", file=fh)
+              print(f"terraform_external_id={project}_{env}_TERRAFORM_EXTERNAL_ID", file=fh)
+        shell: python

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          repository: nationalarchives/${{ inputs.repo-name }}
           submodules: recursive
           token: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Configure AWS credentials for Lambda

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          repository: nationalarchives/${{ inputs.repo-name }}
           submodules: recursive
           token: ${{ secrets.WORKFLOW_TOKEN }}
       - name: Configure AWS credentials for Lambda

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -12,42 +12,28 @@ on:
       environment:
         type: string
         required: true
-    secrets:
-      MANAGEMENT_ACCOUNT:
+      project:
+        type: string
         required: true
+    secrets:
       WORKFLOW_TOKEN:
         required: true
       SLACK_WEBHOOK:
         required: true
       ACCOUNT_NUMBER:
         required: true
-      INTG_ACCOUNT_NUMBER:
-        required: false
-      STAGING_ACCOUNT_NUMBER:
-        required: false
-      PROD_ACCOUNT_NUMBER:
-        required: false
+      TERRAFORM_ROLE:
+        required: true
+      STATE_BUCKET:
+        required: true
+      DYNAMO_TABLE:
+        required: true
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      account-number-secret: ${{ steps.set-environment-names.outputs.account_number_secret }}
-      title-environment: ${{ steps.set-environment-names.outputs.title_environment }}
-    steps:
-      - id: set-environment-names
-        run: |
-          import os
-          env = "${{ inputs.environment }}"
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            print(f"title_environment={env.title()}", file=fh)
-            print(f"account_number_secret={env.upper()}_ACCOUNT_NUMBER", file=fh)
-        shell: python
   plan:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
-    needs: setup
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -57,7 +43,7 @@ jobs:
       - name: Configure AWS credentials for Lambda
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/MgmtDPGithubTerraformEnvironmentsRole${{ needs.setup.outputs.title-environment }}
+          role-to-assume: ${{ secrets.TERRAFORM_ROLE }}
           aws-region: eu-west-2
           role-session-name: TerraformRole
       - uses: hashicorp/setup-terraform@v1
@@ -68,15 +54,17 @@ jobs:
         env:
           GITHUB_OWNER: nationalarchives
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-          TF_VAR_dp_account_number: ${{ secrets[needs.setup.outputs.account-number-secret] }}
-          TF_VAR_project: dr2
+          TF_VAR_account_number: ${{ secrets.ACCOUNT_NUMBER }}
+          TF_VAR_project: ${{ inputs.project }}
         run: |
-          terraform init
-          terraform workspace select ${{ inputs.environment }}
+          terraform init -backend-config="bucket=${{ secrets.STATE_BUCKET }}" --backend-config="dynamodb_table=${{ secrets.DYNAMO_TABLE }}"
+          terraform workspace select ${{ github.event.inputs.environment }}
           pip install boto3
-          terraform plan -no-color -out=out > /dev/null
-          terraform show -no-color out > out.plan
-          python $GITHUB_WORKSPACE/.github/scripts/logs.py out.plan "${{ github.run_id }}${{ github.run_attempt }}" ${{ inputs.environment }}
+          set -e
+          EXIT_CODE=0
+          terraform plan -no-color > out.plan 2>&1 || EXIT_CODE=$?
+          python $GITHUB_WORKSPACE/.github/scripts/logs.py out.plan "${{ github.run_id }}${{ github.run_attempt }}" ${{ github.event.inputs.environment }}
+          exit $EXIT_CODE
       - uses: nationalarchives/dr2-github-actions/.github/actions/slack-send@main
         with:
           message: |
@@ -91,8 +79,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     needs:
       - plan
-      - setup
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}-${{ inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -102,7 +89,7 @@ jobs:
       - name: Configure AWS credentials for Lambda
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/MgmtDPGithubTerraformEnvironmentsRole${{ needs.setup.outputs.title-environment }}
+          role-to-assume: ${{ secrets.TERRAFORM_ROLE }}
           aws-region: eu-west-2
           role-session-name: TerraformRole
       - uses: hashicorp/setup-terraform@v1
@@ -112,11 +99,17 @@ jobs:
         env:
           GITHUB_OWNER: nationalarchives
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-          TF_VAR_dp_account_number: ${{ secrets.ACCOUNT_NUMBER }}
+          TF_VAR_account_number: ${{ secrets.ACCOUNT_NUMBER }}
+          TF_VAR_project: ${{ inputs.project }}
         run: |
-          terraform init
-          terraform workspace select ${{ inputs.environment }}
-          terraform apply --auto-approve > /dev/null
+          terraform init -backend-config="bucket=${{ secrets.STATE_BUCKET }}" --backend-config="dynamodb_table=${{ secrets.DYNAMO_TABLE }}"
+          terraform workspace select ${{ github.event.inputs.environment }}
+          pip install boto3
+          set -e
+          EXIT_CODE=0
+          terraform apply --auto-approve > out.apply 2>&1 || EXIT_CODE=$?
+          python $GITHUB_WORKSPACE/.github/scripts/logs.py out.apply "${{ github.run_id }}${{ github.run_attempt }}1" ${{ github.event.inputs.environment }}
+          exit $EXIT_CODE
       - id: next-tag
         uses: nationalarchives/dr2-github-actions/.github/actions/get-next-version@main
         with:

--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -15,6 +15,10 @@ on:
         required: true
       WORKFLOW_TOKEN:
         required: true
+      STATE_BUCKET:
+        required: true
+      DYNAMO_TABLE:
+        required: true
 jobs:
   terraform-check:
     runs-on: ubuntu-latest
@@ -47,7 +51,7 @@ jobs:
         run: terraform fmt -check --recursive
       - name: Terraform Init
         id: init
-        run: terraform init
+        run: terraform init -backend-config="bucket=${{ secrets.STATE_BUCKET }}" --backend-config="dynamodb_table=${{ secrets.DYNAMO_TABLE }}"
       - name: Select integration workspace
         if: inputs.use-workspace
         run: terraform workspace select intg


### PR DESCRIPTION
It now takes a project parameter and a secret for the state bucket, dynamo state lock table and the terraform role to assume.

This may be suitable for a `da-github-actions` but for now I'll leave it as is.

I've also added in a workflow which sets project and environment specific secret names as I was doing this a few times over different repos.
