### PR TITLE
Use the inputs passed to workflow

### DIFF
--- a/.github/workflows/set_terraform_var_names.yml
+++ b/.github/workflows/set_terraform_var_names.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           import os
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-              project = "${{ github.event.inputs.project }}".upper()
-              env = "${{ github.event.inputs.environment }}".upper()
+              project = "${{ inputs.project }}".upper()
+              env = "${{ inputs.environment }}".upper()
               print(f"project_upper={project}", file=fh)
               print(f"environment_upper={env}", file=fh)
               print(f"management_account={project}_MANAGEMENT_ACCOUNT", file=fh)

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -80,7 +80,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     needs:
       - plan
-    environment: ${{ inputs.environment }}-${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Using github.event.inputs.xxx uses the inputs from the calling workflow. So we were getting the environment because that's set on the terraform apply job but not the project because that isn't.

This uses the values passed in which gives the correct secret names

It was also trying to set the environment as intg-intg which is unhelpful. 