### PR TITLE
Remove hard coded version.

### DIFF
--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -48,8 +48,6 @@ jobs:
           aws-region: eu-west-2
           role-session-name: TerraformRole
       - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.5.1
       - name: Terraform Plan
         id: plan
         env:
@@ -95,8 +93,6 @@ jobs:
           aws-region: eu-west-2
           role-session-name: TerraformRole
       - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.5.1
       - name: Run apply
         env:
           GITHUB_OWNER: nationalarchives


### PR DESCRIPTION
I copied this from TDR where we used to pin the versions because terraform used to make breaking changes. Now they're on version 1.x.x, they've promised they won't so I think this is ok.