### PR TITLE
Downgrade ubuntu

### DIFF
--- a/.github/workflows/dr2_test.yml
+++ b/.github/workflows/dr2_test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: nationalarchives/dr2-github-actions/.github/actions/run-git-secrets@main


### PR DESCRIPTION
This is so we can use sbt which has been removed. We'll come up with a more permanent solution later.