### PR TITLE
DR2-2213 Don't change the backend config.

### DIFF
--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -24,10 +24,6 @@ on:
         required: true
       TERRAFORM_ROLE:
         required: true
-      STATE_BUCKET:
-        required: true
-      DYNAMO_TABLE:
-        required: true
 jobs:
   plan:
     runs-on: ubuntu-latest
@@ -56,7 +52,7 @@ jobs:
           TF_VAR_account_number: ${{ secrets.ACCOUNT_NUMBER }}
           TF_VAR_project: ${{ inputs.project }}
         run: |
-          terraform init -backend-config="bucket=${{ secrets.STATE_BUCKET }}" --backend-config="dynamodb_table=${{ secrets.DYNAMO_TABLE }}"
+          terraform init 
           terraform workspace select ${{ github.event.inputs.environment }}
           pip install boto3
           set -e
@@ -100,7 +96,7 @@ jobs:
           TF_VAR_account_number: ${{ secrets.ACCOUNT_NUMBER }}
           TF_VAR_project: ${{ inputs.project }}
         run: |
-          terraform init -backend-config="bucket=${{ secrets.STATE_BUCKET }}" --backend-config="dynamodb_table=${{ secrets.DYNAMO_TABLE }}"
+          terraform init
           terraform workspace select ${{ github.event.inputs.environment }}
           pip install boto3
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
           slack-url: https://example.com
       - run: exit 1
         continue-on-error: false
-        if: steps.slack-send.outputs.status != 200
+        if: steps.slack-send.outputs.status != 403


### PR DESCRIPTION
This was originally done like this so we could run the tdr-aws-accounts
and tna-custodian repos but we're not doing either of those things now.

Also, we shouldn't be using Dynamo state lock so this will remove it.
